### PR TITLE
Normalize confidence to output [0,1]

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -287,8 +287,8 @@ pub fn beam_search<D: Data<Elem = f32>>(
         // }
     }
     let mut normalize_denominator :f32 = 0.00;
-    for i in 0..beam.len()  {
-        normalize_denominator += beam[i].probability()
+    for mut x in &mut beam  {
+        normalize_denominator += x.probability()
     }
     let mut path = Vec::new();
     let mut sequence = String::new();

--- a/src/search.rs
+++ b/src/search.rs
@@ -286,6 +286,10 @@ pub fn beam_search<D: Data<Elem = f32>>(
         //     x.gap_prob /= top;
         // }
     }
+    let mut normalize_denominator :f32 = 0.00;
+    for i in 0..beam.len()  {
+        normalize_denominator += beam[i].probability()
+    }
     let mut path = Vec::new();
     let mut sequence = String::new();
     if beam[0].node != ROOT_NODE {
@@ -295,7 +299,7 @@ pub fn beam_search<D: Data<Elem = f32>>(
         }
     }
     path.reverse();
-    Ok((sequence.chars().rev().collect::<String>(), path,beam[0].probability()))
+    Ok((sequence.chars().rev().collect::<String>(), path, beam[0].probability() / normalize_denominator))
 }
 
 fn find_max(

--- a/src/search.rs
+++ b/src/search.rs
@@ -286,6 +286,11 @@ pub fn beam_search<D: Data<Elem = f32>>(
         //     x.gap_prob /= top;
         // }
     }
+    // The probabilities of the beam paths are summed (using normalize_denominator) 
+    // and used to divide the best path's probability to normalize the outputted 
+    // probabilities to range within [0,1]. This fixes the problem of outputting
+    // very low probability values (like 1e-5) which is not easily interpretable
+    // as confidence scores, which is one of the main use cases of this value.
     let mut normalize_denominator :f32 = 0.00;
     for mut x in &mut beam  {
         normalize_denominator += x.probability()


### PR DESCRIPTION
A quick snippet at the end of the beam search module to normalize the outputted values to restrict within [0,1].

Here is the latency metrics for the baseline (master branch and the fixes by this commit). The `--release` in `cargo run` was vital to keep the latency constant.

| Build Type                       | Time taken by cURL response |
|--------------------------------|--------|
| Baseline                       | 0.7941 |
| Fix (with `--release` builds)    | 0.8371 |
| Fix (without `--release` builds) | 1.3659 |